### PR TITLE
implemented atexit to close panel interfaces on exit

### DIFF
--- a/pyoperant/behavior/two_alt_choice.py
+++ b/pyoperant/behavior/two_alt_choice.py
@@ -560,5 +560,11 @@ if __name__ == "__main__":
 
     panel = PANELS[parameters['panel_name']]()
 
+    def close_panel(panel):
+        panel.close()
+
     exp = TwoAltChoiceExp(panel=panel,**parameters)
+
+    atexit.register(close_panel,exp.panel)
+
     exp.run()

--- a/pyoperant/panels.py
+++ b/pyoperant/panels.py
@@ -44,3 +44,10 @@ class BasePanel(object):
 
     def reset(self):
          raise NotImplementedError
+
+    def close(self):
+        for lbl, interface in self.interfaces:
+            try:
+                interface.close()
+            except AttributeError:
+                pass


### PR DESCRIPTION
_PLEASE REVIEW_

This is a first attempt to properly close out handlers when a process is killed.

The current problem is that when passing a SIGTERM signal to the process, the PyAudio device interface isn't closing out properly. Apparently the `__del__` methods don't always get called when the process gets a TERM signal. We have a few options:
1. use the `atexit` module to call a cleanup function when the process exits
2. run the experiment in its own thread, where we can define explicitly how to handle TERM/KILL/etc
3. use the `signal` module to handle SIGTERM
