### PR TITLE
run experiments from single command line script

### DIFF
--- a/pyoperant/behavior/__init__.py
+++ b/pyoperant/behavior/__init__.py
@@ -1,0 +1,2 @@
+from pyoperant.behavior.two_alt_choice import *
+from pyoperant.behavior.lights import *

--- a/pyoperantrun.py
+++ b/pyoperantrun.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+def parse_commandline(arg_str=sys.argv[1:]):
+    """ parse command line arguments
+
+    """
+    parser=ArgumentParser()
+    parser.add_argument('protocol', 
+                        action='store', 
+                        type=str, 
+                        required=True,
+                        help='(str) experiment protocol'
+                        )
+    parser.add_argument('-P', '--panel',
+                        action='store', 
+                        type=str, 
+                        dest='panel', 
+                        required=True,
+                        help='(string) panel identifier'
+                        )
+    parser.add_argument('-S', '--subject',
+                        action='store', 
+                        type=str, 
+                        dest='subject', 
+                        required=True,
+                        help='subject identifier'
+                        )
+    parser.add_argument('-c','--config',
+                        action='store', 
+                        type=str, 
+                        dest='config_file', 
+                        default='config.json', 
+                        required=False,
+                        help='configuration file [default: %(default)s]'
+                        )
+    args = parser.parse_args(arg_str)
+    return vars(args)
+
+if __name__ == "__main__":
+
+    try: import simplejson as json
+    except ImportError: import json
+
+    from pyoperant.local import PANELS
+
+    try:
+        from pyoperant.local import BEHAVIORS:
+    except ImportError:
+        BEHAVIORS = ['pyoperant.behavior']
+
+    cmd_line = parse_commandline()
+    with open(cmd_line['config_file'], 'rb') as config:
+            parameters = json.load(config)
+
+    for package in BEHAVIORS:
+        try:
+            BehaviorProtocol = getattr(__import__(package, fromlist=[cmd_line.protocol]), cmd_line.protocol)
+            break
+        except ImportError:
+            continue
+
+    if parameters['debug']:
+        print parameters
+        print PANELS
+
+    behavior = BehaviorProtocol(panel=PANELS[parameters[cmd_line.panel]](),
+                                subject=cmd_line.subject,
+                                **parameters,
+                                )
+    behavior.run()


### PR DESCRIPTION
note: UNTESTED, please review

the goal with this is to run experiments from a single command:

```
>> pyoperantrun.py TwoAltChoiceExp --panel='Panel3' --subject='B999'
```

this opens up a few immediate benefits:
- we no longer need to define `if __name__ == "__main__"` for every behavior protocol 
- we no longer have to set executable permissions on each behavior protocol file.
- we no longer have to register each behavior protocol with v/zstart 
- we can now have multiple behavior protocols defined in a single file 

this approach also has potential future benefits:
- we can start isolating experiments to threads, which will facilitate closing out hardware appropriately
- by separating the behavior protocol (say, TwoAltChoiceExp) from the process that runs it (pyoperantrun.py) we are a step closer to running multiple behavior protocols from a single process and being able to stop using our old PERL scripts

rather than registering each script with our `start` PERL script, this will load any behavior scripts that exist in `pyoperant.behavior` OR it will search the packages listed in `BEHAVIORS` in `pyoperant.local`
