### PR TITLE
addresses bug #77

### DIFF
--- a/pyoperant/behavior/two_alt_choice.py
+++ b/pyoperant/behavior/two_alt_choice.py
@@ -372,6 +372,7 @@ class TwoAltChoiceExp(base.BaseExp):
         while trial_time is None:
             if self.check_session_schedule()==False:
                 self.panel.center.off()
+                self.panel.speaker.stop()
                 raise EndSession
             else:
                 trial_time = self.panel.center.poll(timeout=60.0)

--- a/pyoperant/interfaces/pyaudio_.py
+++ b/pyoperant/interfaces/pyaudio_.py
@@ -91,3 +91,7 @@ class PyAudioInterface(base_.BaseInterface):
             self.stream.close()
         except AttributeError:
             self.stream = None
+        try:    
+            self.wf.close()
+        except AttributeError:
+            self.wf = None


### PR DESCRIPTION
addresses bug #77
right now it closes stream at end of session

Justin suggested 

non-exclusive options:

catch the pyaudio error & try to close the stream
close the stream at the end of a session
close the stream any time the panel is reset (not a bad idea)
