### PR TITLE
some reorganization to allow more flexible running of behavioral scripts

### DIFF
--- a/pyoperant/behavior/__init__.py
+++ b/pyoperant/behavior/__init__.py
@@ -1,2 +1,2 @@
-from pyoperant.behavior.two_alt_choice import *
-from pyoperant.behavior.lights import *
+from two_alt_choice import *
+from lights import *

--- a/pyoperant/behavior/lights.py
+++ b/pyoperant/behavior/lights.py
@@ -1,4 +1,5 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
+import os
 from pyoperant import utils, components
 from pyoperant.behavior import base
 
@@ -18,19 +19,36 @@ if __name__ == "__main__":
     try: import simplejson as json
     except ImportError: import json
 
-
     from pyoperant.local import PANELS
 
-    cmd_line = utils.parse_commandline()
-    with open(cmd_line['config_file'], 'rb') as config:
-            parameters = json.load(config)
+    try:
+        from pyoperant.local import DATAPATH
+    except ImportError:
+        DATAPATH = '/home/bird/opdat'
 
+
+    cmd_line = utils.parse_commandline()
+
+    experiment_path = os.path.join(DATAPATH,'B'+cmd_line['subj'])
+    config_file = os.path.join(experiment_path,cmd_line['config_file'])
+    stimuli_path = os.path.join(experiment_path,'Stimuli')
+
+    with open(config_file, 'rb') as config:
+            parameters = json.load(config)
 
     if parameters['debug']:
         print parameters
         print PANELS
 
-    panel = PANELS[parameters['panel_name']]()
+    BehaviorProtocol = Lights
 
-    exp = Lights(panel=panel,**parameters)
-    exp.run()
+    behavior = BehaviorProtocol(
+        panel=PANELS[str(cmd_line['box'])](),
+        subject='B'+cmd_line['subj'],
+        panel_name=cmd_line['box'],
+        experiment_path=experiment_path,
+        stim_path=stimuli_path,
+        **parameters
+        )
+
+    behavior.run()

--- a/pyoperant/behavior/lights.py
+++ b/pyoperant/behavior/lights.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-import os
 from pyoperant import utils, components
 from pyoperant.behavior import base
 
@@ -13,42 +11,3 @@ class Lights(base.BaseExp):
             self.panel.reset()
         except components.HopperWontDropError:
             pass
-
-if __name__ == "__main__":
-
-    try: import simplejson as json
-    except ImportError: import json
-
-    from pyoperant.local import PANELS
-
-    try:
-        from pyoperant.local import DATAPATH
-    except ImportError:
-        DATAPATH = '/home/bird/opdat'
-
-
-    cmd_line = utils.parse_commandline()
-
-    experiment_path = os.path.join(DATAPATH,'B'+cmd_line['subj'])
-    config_file = os.path.join(experiment_path,cmd_line['config_file'])
-    stimuli_path = os.path.join(experiment_path,'Stimuli')
-
-    with open(config_file, 'rb') as config:
-            parameters = json.load(config)
-
-    if parameters['debug']:
-        print parameters
-        print PANELS
-
-    BehaviorProtocol = Lights
-
-    behavior = BehaviorProtocol(
-        panel=PANELS[str(cmd_line['box'])](),
-        subject='B'+cmd_line['subj'],
-        panel_name=cmd_line['box'],
-        experiment_path=experiment_path,
-        stim_path=stimuli_path,
-        **parameters
-        )
-
-    behavior.run()

--- a/pyoperant/behavior/shape.py
+++ b/pyoperant/behavior/shape.py
@@ -36,7 +36,7 @@ class Shaper(object):
         self.block5 = self._null_block(5)
 
     def run_shape(self, start_state='block1'):
-        self.log.info('Starting shaping procedure')
+        self.log.warning('Starting shaping procedure')
         utils.run_state_machine(    start_in=start_state,
                                     error_state='block1',
                                     error_callback=self.error_callback,
@@ -62,7 +62,7 @@ class Shaper(object):
 
         def temp():
             self.recent_state = block_num
-            self.log.info('Starting %s'%(self.block_name(block_num)))
+            self.log.warning('Starting %s'%(self.block_name(block_num)))
             utils.run_state_machine(    start_in='init',
                                         error_state='wait',
                                         error_callback=self.error_callback,
@@ -84,7 +84,7 @@ class Shaper(object):
         reverts to revert_state if no response before timeout (60*60*3=10800)"""
         def temp():
             self.recent_state = block_num
-            self.log.info('Starting %s'%(self.block_name(block_num)))
+            self.log.warning('Starting %s'%(self.block_name(block_num)))
             utils.run_state_machine(    start_in='init',
                                         error_state='check',
                                         error_callback=self.error_callback,
@@ -116,7 +116,7 @@ class Shaper(object):
             if not self.responded_block:
                 elapsed_time = (dt.datetime.now() - self.block_start).total_seconds()
                 if elapsed_time > revert_timeout:
-                    self.log.info("No response in block %d, reverting to block %d.  Time: %s"%(self.recent_state, self.recent_state - 1, dt.datetime.now().isoformat(' ')))
+                    self.log.warning("No response in block %d, reverting to block %d.  Time: %s"%(self.recent_state, self.recent_state - 1, dt.datetime.now().isoformat(' ')))
                     return None
             else:
                 if self.response_counter >= reps:
@@ -302,7 +302,7 @@ class Shaper2AC(Shaper):
         key flashes until pecked, then the hopper comes up for 3 sec. Run 100 trials."""
         def temp():
             self.recent_state = block_num
-            self.log.info('Starting %s'%(self.block_name(block_num)))
+            self.log.warning('Starting %s'%(self.block_name(block_num)))
             utils.run_state_machine(    start_in='init',
                                         error_state='check',
                                         error_callback=self.error_callback,
@@ -329,7 +329,7 @@ class Shaper2AC(Shaper):
         until pecked, then food for 2.5 sec.   Run 100 trials."""
         def temp():
             self.recent_state = block_num
-            self.log.info('Starting %s'%(self.block_name(block_num)))
+            self.log.warning('Starting %s'%(self.block_name(block_num)))
             utils.run_state_machine(    start_in='init',
                                         error_state='check',
                                         error_callback=self.error_callback,
@@ -425,7 +425,7 @@ class Shaper3AC(Shaper):
         key flashes (p=0.333) until pecked, then the hopper comes up for 3 sec. Run 150 trials."""
         def temp():
             self.recent_state = block_num
-            self.log.info('Starting %s'%(self.block_name(block_num)))
+            self.log.warning('Starting %s'%(self.block_name(block_num)))
             utils.run_state_machine(    start_in='init',
                                         error_state='check',
                                         error_callback=self.error_callback,
@@ -454,7 +454,7 @@ class Shaper3AC(Shaper):
         until pecked, then food for 2.5 sec.   Run 150 trials."""
         def temp():
             self.recent_state = block_num
-            self.log.info('Starting %s'%(self.block_name(block_num)))
+            self.log.warning('Starting %s'%(self.block_name(block_num)))
             utils.run_state_machine(    start_in='init',
                                         error_state='check',
                                         error_callback=self.error_callback,

--- a/pyoperant/behavior/two_alt_choice.py
+++ b/pyoperant/behavior/two_alt_choice.py
@@ -1,5 +1,3 @@
-#!/usr/local/bin/python
-
 import os
 import csv
 import copy
@@ -559,25 +557,3 @@ class TwoAltChoiceExp(base.BaseExp):
 
     def punish_post(self):
         pass
-
-if __name__ == "__main__":
-
-    try: import simplejson as json
-    except ImportError: import json
-
-    from pyoperant.local import PANELS
-
-    cmd_line = utils.parse_commandline()
-    with open(cmd_line['config_file'], 'rb') as config:
-            parameters = json.load(config)
-
-    assert utils.check_cmdline_params(parameters, cmd_line)
-
-    if parameters['debug']:
-        print parameters
-        print PANELS
-
-    panel = PANELS[parameters['panel_name']]()
-
-    exp = TwoAltChoiceExp(panel=panel,**parameters)
-    exp.run()

--- a/pyoperant/local_vogel.py
+++ b/pyoperant/local_vogel.py
@@ -120,7 +120,7 @@ PANELS = {"1": Vogel1,
           }
 
 BEHAVIORS = ['pyoperant.behavior',
-             'glab_behaviors.evidence_accum',
+             'glab_behaviors',
             ]
 
 DATA_PATH = '/home/bird/opdat/'

--- a/pyoperant/local_vogel.py
+++ b/pyoperant/local_vogel.py
@@ -120,7 +120,7 @@ PANELS = {"1": Vogel1,
           }
 
 BEHAVIORS = ['pyoperant.behavior',
-             'evidence_accum'
+             'glab_behaviors.evidence_accum',
             ]
 
 DATA_PATH = '/home/bird/opdat/'

--- a/pyoperant/local_vogel.py
+++ b/pyoperant/local_vogel.py
@@ -120,7 +120,7 @@ PANELS = {"1": Vogel1,
           }
 
 BEHAVIORS = ['pyoperant.behavior',
-             # 'py-behaviors'
+             'evidence_accum'
             ]
 
 DATA_PATH = '/home/bird/opdat/'

--- a/pyoperant/local_zog.py
+++ b/pyoperant/local_zog.py
@@ -214,25 +214,25 @@ class Zog12(ZogCuePanel):
 
 PANELS = {
           # "Zog1": Zog1,
-          "Zog2": Zog2,
-          "Zog3": Zog3,
-          "Zog4": Zog4,
-          "Zog5": Zog5,
-          "Zog6": Zog6,
-          "Zog7": Zog7,
-          "Zog8": Zog8,
-          "Zog9": Zog9,
-          "Zog10": Zog10,
-          "Zog11": Zog11,
-          "Zog12": Zog12,
-          "Zog13": Zog13,
-          "Zog14": Zog14,
-          "Zog15": Zog15,
-          "Zog16": Zog16,
+          "2": Zog2,
+          "3": Zog3,
+          "4": Zog4,
+          "5": Zog5,
+          "6": Zog6,
+          "7": Zog7,
+          "8": Zog8,
+          "9": Zog9,
+          "10": Zog10,
+          "11": Zog11,
+          "12": Zog12,
+          "13": Zog13,
+          "14": Zog14,
+          "15": Zog15,
+          "16": Zog16,
           }
 
 BEHAVIORS = ['pyoperant.behavior',
-             # 'py-behaviors'
+             'glab_behaviors'
             ]
 
 DATA_PATH = '/home/bird/opdat/'

--- a/scripts/allsummary.py
+++ b/scripts/allsummary.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+import re
+import datetime as dt
+from glab_common.utils import load_data_pandas
+from socket import gethostname
+import warnings
+from pyoperant.local import DATA_PATH
+
+process_fname = DATA_PATH + "panel_subject_behavior"
+
+inf = open(process_fname, 'rt')
+
+box_nums = []
+bird_nums = []
+processes = []
+
+for line in inf.readlines():
+    if line.startswith('#') or not line.strip():
+        pass # skip comment lines & blank lines
+    else:
+        spl_line = line.split()
+        if spl_line[1] == "1": #box enabled
+            box_nums.append(int(spl_line[0]))
+            bird_nums.append(int(spl_line[2]))
+            processes.append(spl_line[4])
+
+inf.close()
+subjects = ['B%d' % (bird_num) for bird_num in bird_nums]
+# load all data
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    behav_data = load_data_pandas(subjects, DATA_PATH);
+
+f = open('/home/bird/all.summary', 'w')
+
+f.write("this all.summary generated at %s\n" % (dt.datetime.now().strftime('%x %X')))
+
+f.write("FeedErr(won't come up, won't go down, already up, resp during feed)\n")
+
+# Now loop through each bird and grab the error info from each summaryDAT file
+for (box, bird, proc) in zip(box_nums, bird_nums, processes):
+    try:
+        if proc in ('shape','lights','pylights', 'lights.py'):
+            f.write("box %d\tB%d\t %s\n" % (box, bird, proc))
+        else:
+            summaryfname = "/home/bird/opdat/B%d/%d.summaryDAT" % (bird, bird)
+            sdat = open(summaryfname, 'rt')
+            sdata = sdat.read()
+            sdat.close()
+            # m = re.search(r"Trials this session: (\w+)", sdata)
+            # trials_run = m.group(1)
+            # m = re.search(r"ops today: (\w+)", sdata)
+            # feeder_ops = m.group(1)
+            # m = re.search(r"d responses: (\w+)", sdata)
+            # rf_resp = m.group(1)
+
+            m = re.search(r"failures today: (\w+)", sdata)
+            hopper_failures = m.group(1)
+            m = re.search(r"down failures today: (\w+)", sdata)
+            godown_failures = m.group(1)
+            m = re.search(r"up failures today: (\w+)", sdata)
+            goup_failures = m.group(1)
+            m = re.search(r"Responses during feed: (\w+)", sdata)
+            resp_feed = m.group(1)
+            # m = re.search(r"Last trial run @: (\w+)\s+(\w+)\s+(\d+)\s+(\d+)\:(\d+)\:(\d+)", sdata)
+            # last_trial_day = int(m.group(3))
+            # last_trial_hour = int(m.group(4))
+            # last_trial_min = int(m.group(5))
+            # last_trial_month = m.group(2)
+
+            # # Figure out time since last trial
+            # curr_time = datetime.now()
+            # if curr_time.day != last_trial_day:
+            #     datediff = '(not today)'
+            # else:
+            #     timediff = (curr_time.hour - last_trial_hour)*60 + (curr_time.minute - last_trial_min)
+            #     datediff = '(%d mins ago)' % timediff
+            
+            # calculate output fields not written directly
+            #TOs = int(rf_resp) - int(feeder_ops)
+            #noRs = int(trials_run) - int(rf_resp)
+            
+
+
+            subj = 'B%d' % (bird)
+            df = behav_data[subj]
+            todays_data = df[(df.index.date-dt.datetime.today().date()) == dt.timedelta(days=0)]
+            feeder_ops = sum(todays_data['reward'].values)
+            trials_run = len(todays_data)
+            noRs = sum(todays_data['response'].values=='none')
+            TOs = trials_run-feeder_ops-noRs
+            last_trial_time = todays_data.sort().tail().index[-1]
+            if last_trial_time.day != dt.datetime.now().day:
+                datediff = '(not today)'
+            else:
+                minutes_ago = (dt.datetime.now() - last_trial_time).seconds / 60
+                datediff = '(%d mins ago)' % (minutes_ago)
+            
+            outline = "box %d\tB%d\t %s  \ttrls=%s  \tfeeds=%d  \tTOs=%d  \tnoRs=%d  \tFeedErrs=(%s,%s,%s,%s)  \tlast @ %s %s\n" % (box, bird, proc, trials_run, feeder_ops, TOs, noRs, 
+              hopper_failures, godown_failures, goup_failures, resp_feed, last_trial_time.strftime('%x %X'), datediff)
+            f.write(outline)
+    except Exception as e:
+        f.write("box %d\tB%d\t Error opening SummaryDat or incorrect format\n" % (box, bird))
+        #print e
+
+f.close()

--- a/scripts/allsummary.py
+++ b/scripts/allsummary.py
@@ -31,7 +31,7 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     behav_data = load_data_pandas(subjects, DATA_PATH);
 
-f = open('/home/bird/all.summary', 'w')
+f = open(DATA_PATH + 'all.summary', 'w')
 
 f.write("this all.summary generated at %s\n" % (dt.datetime.now().strftime('%x %X')))
 

--- a/scripts/behave
+++ b/scripts/behave
@@ -46,13 +46,14 @@ def find_protocol(protocol,package_list):
     packages = [importlib.import_module(pstr) for pstr in package_list]
     for p in packages:
         try:
-            return getattr(p, protocol)
+            Protocol = getattr(p, protocol)
+            break
         except AttributeError:
             continue
 
-if __name__ == "__main__":
+    return Protocol
 
-
+def main():
     from pyoperant.local import PANELS
 
     try:
@@ -67,7 +68,9 @@ if __name__ == "__main__":
 
     cmd_line = parse_commandline()
 
-    config_file = os.path.join(DATAPATH,cmd_line['subject'],cmd_line['config_file'])
+    experiment_path = os.path.join(DATAPATH,cmd_line['subj'])
+    config_file = os.path.join(experiment_path,cmd_line['config_file'])
+    stimuli_path = os.path.join(experiment_path,'Stimuli')
 
     with open(config_file, 'rb') as config:
         parameters = json.load(config)
@@ -82,8 +85,12 @@ if __name__ == "__main__":
         panel=PANELS[cmd_line['panel']](),
         subject=cmd_line['subject'],
         panel_name=cmd_line['panel'],
+        experiment_path=experiment_path,
+        stim_path=stimuli_path,
         **parameters
         )
 
     behavior.run()
 
+if __name__ == "__main__":
+    main()

--- a/scripts/behave
+++ b/scripts/behave
@@ -43,15 +43,17 @@ def parse_commandline(arg_str=sys.argv[1:]):
     return vars(args)
 
 def find_protocol(protocol,package_list):
-    packages = [importlib.import_module(pstr) for pstr in package_list]
-    for p in packages:
+    packages = []
+    for pstr in package_list:
+        p = importlib.import_module(pstr)
+
         try:
             Protocol = getattr(p, protocol)
-            break
+            return Protocol
         except AttributeError:
             continue
+    raise ImportError('%s not found' % protocol)
 
-    return Protocol
 
 def main():
     from pyoperant.local import PANELS
@@ -68,7 +70,7 @@ def main():
 
     cmd_line = parse_commandline()
 
-    experiment_path = os.path.join(DATAPATH,cmd_line['subj'])
+    experiment_path = os.path.join(DATAPATH,cmd_line['subject'])
     config_file = os.path.join(experiment_path,cmd_line['config_file'])
     stimuli_path = os.path.join(experiment_path,'Stimuli')
 

--- a/scripts/pyoperantctl
+++ b/scripts/pyoperantctl
@@ -8,7 +8,7 @@ $opdatdir="/home/bird/opdat/";
 
 #here you should list the programs that may be run
 #this program will kill these processes if they are running for a box if the file above has a line for that box that doesn't match
-@psnames=("rand","gngseq","gngseq_vr","JCgngseq","shape","shape_hold","gng","femxpeck","femxperch","femxentropy","2ac_entropy", "2ac","2acQLT", "2acsnip", "2acstreamchg_train", "2acstreamchg","lights","pylights", "3ac", "3ac2", "songchoice", "songchoicetrain", "gngpass","gngpeck","holdbeak","spkchoice","spkchoicetrn", "spkchcholdtrn","classchoice","cc1spk","changepeck","2acmatchblock","lights.py","evidence_accum.py","three_ac_matching.py","three_ac_matching_shape.py","diag_trans.py","two_alt_choice.py","run-pyoperant");
+@psnames=("behave",);
 
 sub checkoptions(@);
 
@@ -65,14 +65,14 @@ while(scalar(@processes)>0){
     $ps=pop(@processes);
     @info=split(" ",$ps,11);
     chop($info[10]);
-    $info[10] =~ s/^(\/usr\/local\/bin\/python \/usr\/local\/bin\/)//;
+    $info[10] =~ s/^(\/usr\/bin\/python \/usr\/local\/bin\/)//;
     print($info[10]."\n");
     if($info[10] =~ /^($psnames)/){
 	@pspieces=split(" ",$info[10]);
 
 	$j=0;
 	while(scalar(@pspieces)>$j){
-	    if($pspieces[$j] eq "-B"){
+	    if($pspieces[$j] eq "-P"){
 		$boxNum = $pspieces[1 + $j];
 	    } elsif ($pspieces[$j] eq "-S") {
 		$birdID = $pspieces[1 + $j];

--- a/scripts/pyoperantctl
+++ b/scripts/pyoperantctl
@@ -1,8 +1,78 @@
-#!/usr/bin/perl
-require "/home/bird/bin/perltools/load_lab_file.perl";
-require "/home/bird/bin/perltools/get_globals.perl";
+#!/usr/bin/env perl
+
+$numBoxes=16;
 
 $opdatdir="/home/bird/opdat/";
+$file="${opdatdir}panel_subject_behavior";
+
+#this code parses a file as described in panel_subject_behavior
+sub trim($)
+{
+        my $string = shift;
+        $string =~ s/^\s+//;
+        $string =~ s/\s+$//;
+        return $string;
+}
+
+sub readfile{
+    ($file, $numboxes)=@_;
+
+    @lines=`cat $file`;
+
+    $i=0;
+    while($numBoxes>$i){
+    @boxdone[$i]=0;
+    $i++;
+    }
+
+    $j=0;
+    $realLineNum=0;
+    while(scalar(@lines)>$j){
+    $line=trim($lines[$j]);
+
+    if($line =~ /^\#/){
+        #print("ignoring a comment line\n");
+    } elsif ($line =~ /\S+/) {
+
+        @fields=split(/\s+/,$line,5);
+
+        if(scalar(@fields)==5){
+        if($fields[0]>0 && $fields[0]<=$numboxes){
+            if($boxdone[$fields[0] - 1]==0){
+            $boxdone[$fields[0] - 1]=1;
+
+            $f=0;
+            foreach $str(@fields){
+
+                $current=trim($str);
+                while($current =~ /<(\d+)>/ && $1 > 0 && $1 <= $f){
+                #print "\n$current matched for $1\n";
+                $current =~ s/<(\d+)>/$fixed[$realLineNum][$1-1]/;
+                }
+                $fixed[$realLineNum][$f]=$current;
+
+                #print "$fixed[$realLineNum][$f] \t";
+                $f++;
+            }
+            #print "\n";
+            $realLineNum++;
+
+            } else {
+            print("ignoring an additional line for box ".$fields[0]." in the file ".$file."\n");
+            }
+        } else {
+            print("ignoring a line for box ".$fields[0]." in the file ".$file." because it is less than 0 or bigger than ".$numboxes."\n");
+        }
+        } else {
+        print("ignoring a line in the file ".$file." that contains something other than 5 columns\n");
+        }
+    } else {
+        #print "ignoring a blank line\n";
+    }
+    $j++;
+    }
+    return @fixed;
+}
 
 @data=readfile($file, $numBoxes);
 

--- a/scripts/pyoperantctl
+++ b/scripts/pyoperantctl
@@ -1,0 +1,233 @@
+#!/usr/bin/perl
+require "/home/bird/bin/perltools/load_lab_file.perl";
+require "/home/bird/bin/perltools/get_globals.perl";
+
+$opdatdir="/home/bird/opdat/";
+
+@data=readfile($file, $numBoxes);
+
+#here you should list the programs that may be run
+#this program will kill these processes if they are running for a box if the file above has a line for that box that doesn't match
+@psnames=("rand","gngseq","gngseq_vr","JCgngseq","shape","shape_hold","gng","femxpeck","femxperch","femxentropy","2ac_entropy", "2ac","2acQLT", "2acsnip", "2acstreamchg_train", "2acstreamchg","lights","pylights", "3ac", "3ac2", "songchoice", "songchoicetrain", "gngpass","gngpeck","holdbeak","spkchoice","spkchoicetrn", "spkchcholdtrn","classchoice","cc1spk","changepeck","2acmatchblock","lights.py","evidence_accum.py","three_ac_matching.py","three_ac_matching_shape.py","diag_trans.py","two_alt_choice.py","run-pyoperant");
+
+sub checkoptions(@);
+
+$psnames=join("|",@psnames);
+@processes=`ps waux | egrep '$psnames'`;
+
+#pass a string containing s as argument 1 to activate starting
+$shouldStartProcesses=0;
+#pass a string containing k as argument 1 to activate killing
+$shouldKillProcesses=0;
+#pass a string containing d as argument 1 to kill all (needs k to actually work)
+$shouldKillAll=0;
+
+if($#ARGV>=0){
+   #print("$ARGV[0] is first argument\n");
+   if($ARGV[0] =~ /k/){
+       print("activating killing\n");
+       $shouldKillProcesses=1;
+   } else {
+       print("killing inactive.  pass a command line argument containing 'k' to activate.\n");
+   }
+   if($ARGV[0] =~ /s/){
+       print("activating starting\n");
+       $shouldStartProcesses=1;
+   } else {
+       print("starting inactive.  pass a command line argument containing 's' to activate.\n");
+   }
+   if($ARGV[0] =~ /d/){
+       print("killing all.\n");
+       $shouldKillAll=1;
+       if(!$shouldKillProcesses){
+	   print("you need to also pass 'k' in order for killing all to actually kill.\n");
+       }
+   } else {
+       print("pass a command line argument containing 'd' to bring down all processes.\n");
+   }
+} else {
+    print("starting and killing inactive.  pass a command line argument containing 's' and/or 'k', respectively, to activate.\n");
+    print("pass a command line argument containing 'd' to bring down all processes.\n");
+}
+
+if($#ARGV>=1){
+    $killstring = $ARGV[1];
+    print("kill string is $killstring\n");
+} else {
+    $killstring='';
+    print("a second argument would have been added to the logfiles when processes are killed (ie a reason for killing the process)\n");
+}
+
+print("\n");
+
+$i=0;
+while(scalar(@processes)>0){
+    $ps=pop(@processes);
+    @info=split(" ",$ps,11);
+    chop($info[10]);
+    $info[10] =~ s/^(\/usr\/local\/bin\/python \/usr\/local\/bin\/)//;
+    print($info[10]."\n");
+    if($info[10] =~ /^($psnames)/){
+	@pspieces=split(" ",$info[10]);
+
+	$j=0;
+	while(scalar(@pspieces)>$j){
+	    if($pspieces[$j] eq "-B"){
+		$boxNum = $pspieces[1 + $j];
+	    } elsif ($pspieces[$j] eq "-S") {
+		$birdID = $pspieces[1 + $j];
+	    }
+	    $j++;
+	}
+	@indProcesses[$i]=$info[10];
+	@indBoxes[$i]=$boxNum;
+	@indBirdIDs[$i]=$birdID;
+	@indIDs[$i]=$info[1];
+	@indStatuses[$i]=$info[7];
+	$i++;
+    }
+}
+
+$i=0;
+while($numBoxes>$i){
+    @boxCorrect[$i]=-1;
+    @correctProgram[$i]="";
+    @directory[$i]="";
+    @birdid[$i]=0;
+    $i++;
+}
+
+($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time);
+$date = sprintf("%02d-%02d-%02d",(1+$mon),$mday,(1900+$year-2000));
+
+foreach $row(@data){
+    @fields=@$row;
+
+    if($fields[1]!='1'){
+	print("box $fields[0] disabled\n");
+    }
+
+    $boxCorrect[$fields[0] - 1]=0;
+    if($shouldKillAll || $fields[1]!='1'){
+	$correctProgram[$fields[0] - 1]="NONE";
+    } else {
+	$correctProgram[$fields[0] - 1]=$fields[4];
+    }
+    $directory[$fields[0] - 1]=$fields[3];
+    $birdid[$fields[0] - 1]=$fields[2];
+
+    $i=0;
+    while(scalar(@indProcesses)>$i){
+	if($indBoxes[$i]==$fields[0]){
+#	    if($indProcesses[$i] eq $fields[3]){
+	    if(checkoptions($indProcesses[$i], $correctProgram[$fields[0] - 1])){
+		if ($indStatuses[$i] eq "SL" || $indStatuses[$i] eq "RL"){
+		    if($boxCorrect[$fields[0] - 1]==0){
+			print("box ".$fields[0]." correctly running ".$indProcesses[$i]."\n");
+			$boxCorrect[$fields[0] - 1]=1;
+		    } else {
+			print("box ".$fields[0]." INCORRECTLY running duplicate copy of ".$indProcesses[$i]." you should kill one of them\n");
+		    }
+		} elsif ($indStatuses[$i] eq "Ss") {
+		    print("box ".$fields[0]." found running session leader process ".$indIDs[$i]."\n");
+		} else {
+		    print("box ".$fields[0]." running correct process ".$indProcesses[$i]." but with status ".$indStatuses[$i]." you should investigate ".$indIDs[$i]."\n");
+		    $boxCorrect[$fields[0] - 1]=1;
+		}
+	    } else {
+		if($indStatuses[$i] eq "Ss"){
+		    print("box ".$fields[0]." running session leader process ".$indIDs[$i]."\n");
+		} else {
+		    print("box ".$fields[0]." INCORRECTLY running ".$indProcesses[$i]." should kill ".$indIDs[$i]."\n");
+		    $killID=$indBirdIDs[$i];
+		    $killLog=$opdatdir."B".$killID."/B".$killID."_log.txt";
+		    print("log directory is $killLog\n");
+		    if($shouldKillProcesses){
+			print("attempting to kill $indProcesses[$i] ($indIDs[$i])\n");
+			system "kill $indIDs[$i]";
+			#system "cd $directory[$i]; echo '".$date.": ".$killstring." killing $indProcesses[$i]' >> $opdatdir"."B".$birdid[$i]."/B".$birdid[$i]."_log.txt";
+			system "echo '".$date.": killing $indProcesses[$i] :: $killstring' >> $killLog";
+		    }
+		}
+	    }
+	}
+	$i++;
+    }
+}
+
+$i=0;
+while($i<$numBoxes){
+    if($boxCorrect[$i]==0){
+	if($correctProgram[$i] eq "NONE"){
+	    print("box ".($i + 1)." correctly running no program (assuming processes suggested above were killed)\n");
+	} else {
+	    print("box ".($i + 1)." needs to start ".$correctProgram[$i]." in directory ".$directory[$i]."\n");
+
+	    if($shouldStartProcesses){
+		print("attempting to start $correctProgram[$i] in $directory[$i]\n");
+		system "cd $directory[$i]; echo '".$date.": starting $correctProgram[$i]' >> $opdatdir"."B".$birdid[$i]."/B".$birdid[$i]."_log.txt; $correctProgram[$i] &";
+	    }
+	}
+    } elsif ($boxCorrect[$i]==-1){
+	print("box ".($i + 1)." has no line in file ".$file."\n");
+    } elsif ($boxCorrect[$i]==1){
+	#print("box ".($i + 1)." needs no change\n");
+    } else {
+	print("box ".($i + 1)." had some problem that should never happen\n");
+    }
+    $i++;
+}
+
+sub checkoptions(@) {
+	($s1,$s2)=@_;
+
+	$s1=trim($s1);
+	$s2=trim($s2);
+	if($s1=~s/^(\S*)// && $s2=~s/^$1//){
+		$s1=trim($s1);
+		$s2=trim($s2);
+		if($s1=~s/(\S*)$// && $s2=~s/$1$//){
+			$s1=trim($s1);
+			$s2=trim($s2);
+			@s1=split("-",$s1);
+			@s2=split("-",$s2);
+			#print "'".$s1."'"."\t"."'".$s2."'"."\n";
+			@redo=@s2;
+			foreach $o(@s1){
+				@s2=@redo;
+				$o=trim($o);
+				$match=0;
+				$n=0;
+				@redo=();
+				foreach $m(@s2){
+					$m=trim($m);
+					#print "'".$m."'"."\t"."'".$o."'"."\n";
+					if($m=~/^(\S*)\s*(\S*)$/ && $o=~/^$1\s*$2$/){
+						$match=1;
+					} else {
+						$redo[$n]=$m;
+						$n++;
+					}
+				}
+				if($match){
+				} else {
+					#print "no match for option\n";
+					return 0;
+				}
+			}
+			if(scalar(@redo)==0){
+				#success!
+				return 1;
+			} else {
+				#print "leftover options\n";
+				return 0;
+			}
+		} else {
+			#print "not same stimfile\n";
+			return 0;
+		}
+	} else {
+		#print "not same program\n";
+		return 0;
+	}
+}

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@ setup(
     long_description = open('docs/README.rst', 'rt').read(),
     packages = ['pyoperant'],
     requires = ['pyephem','numpy'],
-    scripts = ['scripts/behave'],
+    scripts = [
+        'scripts/behave',
+        'scripts/pyoperantctl',
+        ],
     license = "GNU Affero General Public License v3",
     classifiers = [
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     long_description = open('docs/README.rst', 'rt').read(),
     packages = ['pyoperant'],
     requires = ['pyephem','numpy'],
+    scripts = ['scripts/behave'],
     license = "GNU Affero General Public License v3",
     classifiers = [
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     scripts = [
         'scripts/behave',
         'scripts/pyoperantctl',
+        'scripts/allsummary.py',
         ],
     license = "GNU Affero General Public License v3",
     classifiers = [


### PR DESCRIPTION
this code is currently running on vogel. there are some small changes and some big changes. the big ones:

this adds a new script to the path called `behave` which allows us to run any behavioral protocol without building out the full `if __name__=="__main__"` every single time

instead, we run `behave -P 1 -S B999 TwoAltChoiceExp` to run subject B999 on a two alt choice experiment on panel 1.

this should simplify the process of starting up a new behavioral protocol. currently if you have written a protocol, you need to do a few things for our Perl scripts that manage the panels...

1. make sure Python file containined the protocol is executable
2. add the protocol file to the path
3. add the protocol file to the `xstart` perl script

now we have a few improvements:

1. we can maintain more than one protocol per file
2. we only need to register a python module containing behavioral protocols with the pyoperant local config rather than needing to register every single protocol
3. loading of config files etc is all in `behave` now, so any bugs in loading protocols can be dealt with there.

finally, to deal with the new command format, I've replaced `xstart` with `pyoperantctl`. it works the same as it ever did, but will be installed to the command line when pip installs the package

minor changes:
- during shaping, you'll now receive a "warning" email when transferring between blocks