### PR TITLE
derisking the pyaudio callback

### DIFF
--- a/pyoperant/interfaces/pyaudio_.py
+++ b/pyoperant/interfaces/pyaudio_.py
@@ -22,7 +22,6 @@ class PyAudioInterface(base_.BaseInterface):
         self.device_index = None
         self.stream = None
         self.wf = None
-        self.callback = None
         self.open()
 
     def open(self):
@@ -55,20 +54,13 @@ class PyAudioInterface(base_.BaseInterface):
         else:
             raise InterfaceError('there is something wrong with this wav file')
 
-    def _get_stream(self,start=False):
+    def _get_stream(self,start=False,callback=None):
         """
         """
-        def _callback(in_data, frame_count, time_info, status):
-            try:
-                cont = self.callback()         
-            except TypeError:
-                cont = True
-
-            if cont:
+        if callback is None:
+            def callback(in_data, frame_count, time_info, status):
                 data = self.wf.readframes(frame_count)
                 return (data, pyaudio.paContinue)
-            else:
-                return (0, pyaudio.paComplete)
 
         self.stream = self.pa.open(format=self.pa.get_format_from_width(self.wf.getsampwidth()),
                                    channels=self.wf.getnchannels(),
@@ -76,12 +68,12 @@ class PyAudioInterface(base_.BaseInterface):
                                    output=True,
                                    output_device_index=self.device_index,
                                    start=start,
-                                   stream_callback=_callback)
+                                   stream_callback=callback)
 
-    def _queue_wav(self,wav_file,start=False):
+    def _queue_wav(self,wav_file,start=False,callback=None):
         self.wf = wave.open(wav_file)
         self.validate()
-        self._get_stream(start=start)
+        self._get_stream(start=start,callback=callback)
 
     def _play_wav(self):
         self.stream.start_stream()


### PR DESCRIPTION
this gets rid of the wholly undocumented pyaudio.callback attribute, which allows users to add arbitrary python code into the pyaduio callback

this is risky because code which takes more than trivial processing time can bork the audio.

this change effectively forces any user who wants to manipulate the callback function to read the pyaduio/portaudio documentation and caveats on it's implementation