### PR TITLE
Lights: allow free food access alongside light-schedule control

### DIFF
--- a/example_configs/Lights.json
+++ b/example_configs/Lights.json
@@ -1,5 +1,5 @@
 {
-    "comments": "Minimal smoke-test config for Lights -- only needs BaseExp-level params, no stims/classes.",
+    "comments": "Minimal smoke-test config for Lights -- only needs BaseExp-level params, no stims/classes. free_food_schedule is independent of light_schedule -- it doesn't have to match; omit it entirely to disable free feeding.",
     "experimenter": {
         "name": "smoke test",
         "email": "tgentner@ucsd.edu"
@@ -8,5 +8,6 @@
     "debug": true,
     "log_handlers": [],
     "light_schedule": [["00:00", "23:59"]],
+    "free_food_schedule": [["00:00", "23:59"]],
     "shape": null
 }

--- a/pyoperant/behavior/lights.py
+++ b/pyoperant/behavior/lights.py
@@ -8,12 +8,72 @@ from pyoperant import utils, components
 from pyoperant.behavior import base
 
 class Lights(base.BaseExp):
-    """docstring for Lights"""
+    """A session-less behavior: just keeps the house light on `light_schedule`
+    and, optionally, offers the bird free access to the hopper on
+    `free_food_schedule`. Useful for holding a bird on a light/feeding
+    schedule between real experiments, without running any trials.
+
+    The two schedules are independent -- `free_food_schedule` doesn't have
+    to match `light_schedule`, and free feeding is skipped entirely if
+    `free_food_schedule` isn't set in the config (same as other behaviors).
+    Both use the same format as `light_schedule`, e.g.
+    [["07:00", "19:00"]], and are checked via `utils.check_time`.
+    """
     def __init__(self,  *args, **kwargs):
         super(Lights, self).__init__(*args, **kwargs)
+        self.req_panel_attr.append('reward')
 
     def panel_reset(self):
         try:
             self.panel.reset()
         except components.HopperWontDropError:
             pass
+
+    def _run_idle(self):
+        """Same as BaseExp._run_idle, except the free-food check doesn't
+        require check_session_schedule() -- Lights has no session concept
+        of its own, so that gate would otherwise make free_food_schedule
+        silently inert here."""
+        self.log.debug('Starting _run_idle')
+        if self.check_light_schedule() == False:
+            return 'sleep'
+        elif self._check_free_food_block():
+            return 'free_food_block'
+        else:
+            self.panel_reset()
+            self.log.debug('idling...')
+            utils.wait(self.parameters['idle_poll_interval'])
+            return 'idle'
+
+    def _free_food(self):
+        """A solenoid shouldn't be held energized continuously, so
+        BaseExp._free_food cycles it up/down for the duration of the
+        schedule -- that's still correct here for a solenoid hopper. A
+        servo can safely hold the raised position, though, so use a
+        continuous raise/hold/lower instead of cycling it.
+
+        Falls back to the solenoid-style cycling behavior if the panel's
+        hopper actuator can't be determined."""
+        if getattr(getattr(self.panel, 'hopper', None), '_actuator', None) == 'servo':
+            return self._free_food_continuous()
+        return super(Lights, self)._free_food()
+
+    def _free_food_continuous(self):
+        """Servo-hopper free food: raise once, hold for as long as
+        free_food_schedule stays active, then lower once."""
+        self.log.debug('Starting continuous free food (servo hopper)')
+        try:
+            self.panel.hopper.up()
+        except components.HopperWontComeUpError:
+            self.log.warning("Hopper did not come up for free food")
+            return 'idle'
+
+        while self._check_free_food_block():
+            utils.wait(self.parameters['idle_poll_interval'])
+
+        try:
+            self.panel.hopper.down()
+        except components.HopperWontDropError:
+            self.log.warning("Hopper did not go down after free food")
+
+        return 'idle'

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -88,13 +88,33 @@ class FakeCue(object):
         self.calls.append("off")
 
 
+class FakeHopper(object):
+    """Stands in for a components.Hopper. `actuator` is 'servo' or
+    'solenoid', mirroring the real Hopper's `_actuator` attribute that
+    lights.py's Lights._free_food branches on."""
+
+    def __init__(self, actuator="servo"):
+        self._actuator = actuator
+        self.calls = []
+
+    def up(self):
+        self.calls.append("up")
+
+    def down(self):
+        self.calls.append("down")
+
+    def reward(self, value=1.0):
+        self.calls.append(("reward", value))
+        return dt.datetime.now()
+
+
 class FakePanel(panels.BasePanel):
     """Minimal stand-in for a real hardware Panel -- enough to satisfy
     BaseExp/TwoAltChoiceExp/Shaper without touching any GPIO/serial/audio
     hardware. Subclasses panels.BasePanel because shape.Shaper.__init__
     asserts isinstance(panel, panels.BasePanel)."""
 
-    def __init__(self):
+    def __init__(self, hopper_actuator="servo"):
         super(FakePanel, self).__init__()
         self.house_light = FakeLight()
         self.left = FakePort("left")
@@ -102,6 +122,7 @@ class FakePanel(panels.BasePanel):
         self.right = FakePort("right")
         self.speaker = FakeSpeaker()
         self.cue = FakeCue()
+        self.hopper = FakeHopper(actuator=hopper_actuator)
         self.reset_calls = 0
         self.reward_calls = []
         self.punish_calls = []

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -136,6 +136,62 @@ class TestLights(unittest.TestCase):
                     type(e).__name__, e))
             self.assertEqual(panel.reset_calls, 1)
 
+    def test_Lights_free_food_during_idle(self):
+        """free_food_schedule should trigger the free-food state directly
+        from _run_idle, without needing check_session_schedule() -- see
+        lights.py's _run_idle override.
+
+        Note: doesn't drive exp._free_food() itself -- with an always-on
+        schedule its inner wait/food/checker loop (base.py) never exits,
+        by design (it's meant to keep cycling for as long as the schedule
+        window is open). deliver_free_food() is the actual reward-delivery
+        primitive that loop calls each pass, so exercise that directly."""
+        config = _load_config("Lights")
+        config["free_food_schedule"] = [["00:00", "23:59"]]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = prepare_experiment_dirs(config, tmp_dir)
+            panel = FakePanel()
+            exp = Lights(panel=panel, **config)
+            self.assertEqual(exp._run_idle(), 'free_food_block')
+
+            exp.deliver_free_food(10, 'checker')()
+            self.assertEqual(panel.reward_calls, [10])
+
+    def test_Lights_free_food_servo_continuous(self):
+        """Servo hopper: _free_food should raise once, hold while the
+        schedule stays open, then lower once -- not cycle like the
+        solenoid path does."""
+        config = _load_config("Lights")
+        config["free_food_schedule"] = [["00:00", "23:59"]]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = prepare_experiment_dirs(config, tmp_dir)
+            panel = FakePanel(hopper_actuator="servo")
+            exp = Lights(panel=panel, **config)
+
+            with patch("pyoperant.utils.wait"), \
+                 patch.object(exp, "_check_free_food_block", side_effect=[True, False]):
+                self.assertEqual(exp._free_food(), 'idle')
+
+            self.assertEqual(panel.hopper.calls, ["up", "down"])
+
+    def test_Lights_free_food_solenoid_cycles(self):
+        """Solenoid hopper: _free_food should fall through to BaseExp's
+        existing cycling behavior (feed via panel.reward each pass)
+        unchanged -- the hopper is never held continuously up."""
+        config = _load_config("Lights")
+        config["free_food_schedule"] = [["00:00", "23:59"]]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = prepare_experiment_dirs(config, tmp_dir)
+            panel = FakePanel(hopper_actuator="solenoid")
+            exp = Lights(panel=panel, **config)
+
+            with patch("pyoperant.utils.wait"), \
+                 patch("pyoperant.utils.check_time", return_value=False):
+                self.assertEqual(exp._free_food(), 'idle')
+
+            self.assertEqual(panel.reward_calls, [10])
+            self.assertEqual(panel.hopper.calls, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Lights previously never actually delivered free_food_schedule food -- BaseExp._run_idle only checks free-food status inside the check_session_schedule() branch, which Lights (having no session concept) never enters, so the parameter was silently inert.

- Override _run_idle in Lights to check free-food directly, independent of session scheduling. base.py and every other behavior are untouched.
- Reuse the existing free_food_schedule config key/format (same as light_schedule), documented in Lights' docstring and example config.
- Override _free_food to branch on the panel's hopper actuator: a solenoid shouldn't be held energized continuously, so it keeps BaseExp's existing up/down cycling; a servo can safely hold the raised position, so it's raised once and held for the whole free-food window instead.
- req_panel_attr now requires 'reward' so a panel missing hopper wiring fails fast at startup instead of inside a bare except.
- Extend tests/fixtures.py's FakePanel with a FakeHopper (servo/solenoid) and add TestLights coverage for the idle free-food gate and both hopper-actuator branches.